### PR TITLE
Display source code in fixed-width font

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,6 +137,7 @@ var T = template.Must(template.New("").Funcs(template.FuncMap{
 		position: absolute;
 		display: block;
 		white-space: pre;
+		font-family: monospace;
 		left: var(--number-width);
 		right: calc(var(--info-width) + var(--tags-width));
 		top: 0; bottom: 0;


### PR DESCRIPTION
Code was being displayed in a default proportional-width font; this changes it to use the browser's default fixed-width font.